### PR TITLE
feat: Add Shenzhen Bay to Hong Kong bus route map

### DIFF
--- a/bus_routes.json
+++ b/bus_routes.json
@@ -1,0 +1,74 @@
+[
+  {
+    "routeName": "B2",
+    "destination": "Yuen Long Station",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Yuen Long Station", "lat": 22.4461, "lng": 114.0352}
+    ],
+    "notes": "Intermediate stop data could not be retrieved."
+  },
+  {
+    "routeName": "B2P",
+    "destination": "Tin Tsz Estate",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Tin Tsz Estate", "lat": 22.4528, "lng": 114.0070}
+    ],
+    "notes": "Intermediate stop data could not be retrieved."
+  },
+  {
+    "routeName": "B2X",
+    "destination": "Tin Yiu Estate",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Tin Yiu Estate", "lat": 22.4498, "lng": 114.0034}
+    ],
+    "notes": "Intermediate stop data could not be retrieved. B2X is likely an express route."
+  },
+  {
+    "routeName": "B3",
+    "destination": "Tuen Mun Pier Head",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Tuen Mun Pier Head", "lat": 22.3722, "lng": 113.9661}
+    ],
+    "notes": "Intermediate stop data could not be retrieved."
+  },
+  {
+    "routeName": "B3A",
+    "destination": "Tuen Mun Shan King",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Shan King Estate (Approximate)", "lat": 22.3916, "lng": 113.9771}
+    ],
+    "notes": "Intermediate stop data could not be retrieved. Coordinates for Shan King Estate are an approximation."
+  },
+  {
+    "routeName": "B3M",
+    "destination": "Tuen Mun Station",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Tuen Mun Station", "lat": 22.3952, "lng": 113.9731}
+    ],
+    "notes": "Intermediate stop data could not be retrieved. Tuen Mun Station is an MTR station."
+  },
+  {
+    "routeName": "B3X",
+    "destination": "Tuen Mun Town Centre",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Tuen Mun Town Centre (Approximate)", "lat": 22.3916, "lng": 113.9771}
+    ],
+    "notes": "Intermediate stop data could not be retrieved. B3X is likely an express route. Coordinates for Tuen Mun Town Centre are an approximation."
+  },
+  {
+    "routeName": "Minibus 618",
+    "destination": "Tin Yan Estate",
+    "stops": [
+      {"name": "Shenzhen Bay Port (HK side)", "lat": 22.5039, "lng": 113.9447},
+      {"name": "Tin Yan Estate", "lat": 22.4631, "lng": 113.9960}
+    ],
+    "notes": "Intermediate stop data for minibuses is particularly difficult to find."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 
     <ul class="sidebar-nav">
       <li><a href="http://xilu0.github.io/">Home</a> </li>
+      <li><a href="shenzhen-bay-hk-buses.html">HK Bus Routes (Shenzhen Bay)</a></li>
       
     </ul>
 

--- a/shenzhen-bay-hk-buses.html
+++ b/shenzhen-bay-hk-buses.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bus Routes from Shenzhen Bay Port to Hong Kong</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <link rel="stylesheet" href="css/poole.css">
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <style>
+        html, body {height: 100%; margin: 0; padding: 0;}
+        #map { height: 500px; width: 100%; margin-bottom: 20px; }
+        /* h1 is already centered by poole.css if in container */
+        #route-list-info {
+          list-style-type: none;
+          padding: 0;
+          margin-top: 20px;
+        }
+        #route-list-info li {
+          margin-bottom: 8px;
+          padding: 8px;
+          background-color: #f9f9f9;
+          border-radius: 4px;
+        }
+        #route-list-info li:hover {
+          background-color: #f0f0f0;
+        }
+    </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Bus Routes from Shenzhen Bay Port to Hong Kong</h1>
+    <div id="map"></div>
+    <ul id="route-list-info">
+      <!-- JS will populate this -->
+    </ul>
+  </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const map = L.map('map').setView([22.4, 114.0], 11);
+
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            }).addTo(map);
+
+            const shenzhenBayPortCoords = [22.5039, 113.9447];
+            L.marker(shenzhenBayPortCoords)
+                .addTo(map)
+                .bindPopup('Shenzhen Bay Port (HK Side)');
+
+            const routeListULElement = document.getElementById('route-list-info');
+
+            fetch('bus_routes.json')
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok ' + response.statusText);
+                    }
+                    return response.json();
+                })
+                .then(routes => {
+                    if (!routeListULElement) {
+                        console.error("Error: route-list-info element not found.");
+                        return;
+                    }
+                    routes.forEach(route => {
+                        // Add route to the list below the map
+                        routeListULElement.innerHTML += `<li><strong>${route.routeName}:</strong> ${route.destination} <small>(${route.notes || ''})</small></li>`;
+
+                        if (route.stops && route.stops.length > 1) {
+                            const origin = route.stops[0]; // Shenzhen Bay Port
+                            const destination = route.stops[route.stops.length - 1]; // Last stop is destination
+
+                            const originLatLng = [origin.lat, origin.lng];
+                            const destinationLatLng = [destination.lat, destination.lng];
+
+                            // Add marker for the destination
+                            L.marker(destinationLatLng)
+                                .addTo(map)
+                                .bindPopup(`${route.routeName}: ${destination.name}<br><small>${route.notes || ''}</small>`);
+
+                            // Draw a polyline (straight line)
+                            L.polyline([originLatLng, destinationLatLng], { color: 'blue' })
+                                .addTo(map)
+                                .bindPopup(`${route.routeName}`);
+                        } else {
+                            console.warn(`Route ${route.routeName} does not have enough stops to draw a line.`);
+                        }
+                    });
+                })
+                .catch(error => {
+                    console.error('Error fetching or processing bus routes data:', error);
+                    if (routeListULElement) {
+                        routeListULElement.innerHTML += `<li style="color: red;">Error loading bus routes.</li>`;
+                    }
+                });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new web page that displays bus routes from Shenzhen Bay Port (Hong Kong side) to various destinations in Hong Kong.

Key features:
- Researched and compiled data for 8 bus routes (B2, B2P, B2X, B3, B3A, B3M, B3X, and Minibus 618).
- Created bus_routes.json to store route information including geographic coordinates for the port and destinations.
- Developed shenzhen-bay-hk-buses.html using Leaflet.js to render an interactive map.
- The map displays markers for the origin (Shenzhen Bay Port) and all destinations, with polylines representing the routes.
- Popups on markers and routes provide route information.
- Added a styled list of routes below the map for easy reference.
- The new page is linked from the sidebar navigation in index.html.
- Styling is integrated using the existing poole.css for consistency.

This map aims to help tourists and travelers understand the available bus connections from Shenzhen Bay Port into Hong Kong.